### PR TITLE
Change name of repo in JS back to consumer-credit-trends

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# credit-market-trends
+# consumer-credit-trends
 
 Coming soon.
 
-![Screenshot of credit-market-trends](screenshot.png)
+![Screenshot of consumer-credit-trends](screenshot.png)
 
 
 ## Installation
@@ -59,7 +59,7 @@ which is the chart generator and library used to create the d3 data visualizatio
 
 ## Credits and references
 
-This project uses: 
+This project uses:
 
 - [Capital Framework](https://github.com/cfpb/capital-framework)
 for its user interface and layout components.

--- a/src/static/js/line.js
+++ b/src/static/js/line.js
@@ -2,7 +2,7 @@
 
 var d3 = require( 'd3' );
 var formatDates = require( './formatDates.js' );
-var DATE_FILE_URL = 'https://raw.githubusercontent.com/cfpb/credit-market-trends/master/data/vol_data_AUT.csv';
+var DATE_FILE_URL = 'https://raw.githubusercontent.com/cfpb/consumer-credit-trends/master/data/vol_data_AUT.csv';
 var Y_VALUE_SCALE = 'B' // M for Millions, B for Billions
 var margin = {top: 100, right: 20, bottom: 20, left: 70};
 var width = 770 - margin.left - margin.right;
@@ -62,27 +62,27 @@ d3.csv(DATE_FILE_URL, function(error, data) {
 
   var unadjustedData = data.filter(function(d) { return d.group == false && d.month <= projectedDate; });
 
-  var projectedAdjustedData = data.filter(function(d) { 
-    return d.group == true && d.month >= projectedDate; // last 6 months; 
+  var projectedAdjustedData = data.filter(function(d) {
+    return d.group == true && d.month >= projectedDate; // last 6 months;
   });
 
-  var projectedUnadjustedData = data.filter(function(d) { 
+  var projectedUnadjustedData = data.filter(function(d) {
     return d.group == false && d.month >= projectedDate; // last 6 months;
   });
 
   var minY = d3.min(data, function(d) {
     return d.num
   });
-  // @todo display on Y axis! 
+  // @todo display on Y axis!
   console.log(minY)
 
   // Scale the range of the data
-  x.domain(d3.extent(data, function(d) {    
+  x.domain(d3.extent(data, function(d) {
     return d.month;
   }));
 
-  y.domain(d3.extent(data, function(d) {    
-    return d.num; 
+  y.domain(d3.extent(data, function(d) {
+    return d.num;
   }));
 
   // Add the X Axis
@@ -145,7 +145,7 @@ d3.csv(DATE_FILE_URL, function(error, data) {
       .text( 'Values after ' + formatTime( lastUnprojectedDate ) )
       .attr('x', -70)
       .attr('y', -50);
-  
+
   svg.select( '.axis__projected' )
     .select( '.tick' )
     .append( 'text' )
@@ -154,7 +154,7 @@ d3.csv(DATE_FILE_URL, function(error, data) {
       .attr('y', -15);
 
   // text label for the y axis
-  svg.append("text")             
+  svg.append("text")
     .classed("axis-label", true)
     .attr( 'transform', 'rotate(-90)' )
     .attr( 'text-anchor', 'end' )

--- a/src/static/js/metadata.js
+++ b/src/static/js/metadata.js
@@ -3,7 +3,7 @@
 require('./env.js');
 var moment = require( 'moment' );
 
-var DATA_REPO = 'credit-market-trends';
+var DATA_REPO = 'consumer-credit-trends';
 var DATA_REPO_ORG = 'cfpb';
 var DATA_FILE_PATH = 'data/vol_data_AUT.csv';
 var TOKEN = process.env.GITHUB_ACCESS_TOKEN_KEY;
@@ -31,12 +31,12 @@ function _formatDatePublished( timestamp ) {
     var date_published = moment( timestamp ).format( 'MMMM YYYY' );
     return date_published;
   } else {
-    return '-'; 
+    return '-';
   }
 }
 
 /**
- * Request info about the data set and files from Github. 
+ * Request info about the data set and files from Github.
  */
 
 function init( ) {


### PR DESCRIPTION
Incorrect info about the project was given, and the repo name was changed earlier. This changes it back to the correct and approved name.

Also, my editor automatically makes linting changes.

## Changes

- Correct the value of the DATA_REPO variable
- Correct the value of the DATE_FILE_URL variable
- Assorted linting corrections

## Review

- @cfarm 
- @mistergone 

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
