### PR TITLE
Automate tile maps

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "cf-pagination": "^3.1.1",
     "cf-tables": "^1.1.0",
     "cf-typography": "^3.1.0",
-    "cfpb-chart-builder": "0.0.3",
+    "cfpb-chart-builder": "0.0.6",
     "github-api": "2.3.0",
     "gulp-connect": "5.0.0",
     "html5shiv": "3.7.3",

--- a/src/static/js/templates/charts.js
+++ b/src/static/js/templates/charts.js
@@ -26,7 +26,7 @@ var charts = [{
   "reportType": "origination-activity",  
   "figureID": "figure-1c",
   "source": "map_data_AUT.csv",
-  "elementID": "auto-loan_geo-changes"
+  "elementID": "figure-1c__map__auto"
 },
 {
   "title": "Number of loans originated",
@@ -314,15 +314,15 @@ var charts = [{
   "source": "vol_data_CRC.csv",
   "elementID": "figure-1a__volume__credit-cards"
 },
-// {
-//   "title": "",
-//   "chartType": "map",
-//   "market": "credit-cards",
-//   "reportType": "origination-activity",  
-//   "figureID": "figure-1c",
-//   "source": "map_data_AUT.csv",
-//   "elementID": "auto-loan_geo-changes"
-// },
+{
+  "title": "",
+  "chartType": "map",
+  "market": "credit-cards",
+  "reportType": "origination-activity",  
+  "figureID": "figure-1c",
+  "source": "map_data_CRC.csv",
+  "elementID": "figure-1c__map__credit-cards"
+},
 // {
 //   "title": "Number of loans originated",
 //   "chartType": "bar",
@@ -610,15 +610,15 @@ var charts = [{
   "source": "vol_data_MTG.csv",
   "elementID": "figure-1a__volume__mortgage"
 },
-// {
-//   "title": "",
-//   "chartType": "map",
-//   "market": "mortgages",
-//   "reportType": "origination-activity",  
-//   "figureID": "figure-1c",
-//   "source": "map_data_MTG.csv",
-//   "elementID": "auto-loan_geo-changes"
-// },
+{
+  "title": "",
+  "chartType": "map",
+  "market": "mortgages",
+  "reportType": "origination-activity",  
+  "figureID": "figure-1c",
+  "source": "map_data_MTG.csv",
+  "elementID": "figure-1c__map__mortgage"
+},
 // {
 //   "title": "Number of loans originated",
 //   "chartType": "bar",
@@ -906,15 +906,15 @@ var charts = [{
   "source": "vol_data_STU.csv",
   "elementID": "figure-1a__volume__student"
 },
-// {
-//   "title": "",
-//   "chartType": "map",
-//   "market": "student-loans",
-//   "reportType": "origination-activity",  
-//   "figureID": "figure-1c",
-//   "source": "map_data_STU.csv",
-//   "elementID": "auto-loan_geo-changes"
-// },
+{
+  "title": "",
+  "chartType": "map",
+  "market": "student-loans",
+  "reportType": "origination-activity",  
+  "figureID": "figure-1c",
+  "source": "map_data_STU.csv",
+  "elementID": "figure-1c__map__student"
+},
 // {
 //   "title": "Number of loans originated",
 //   "chartType": "bar",

--- a/src/static/js/tile-map.js
+++ b/src/static/js/tile-map.js
@@ -8,31 +8,9 @@ var strToNum = require( './utils/string-to-number.js' );
 var formatTime = d3.utcFormat( '%b %Y' );
 var charts = require( './templates/charts.js' ); 
 
+var DATA_FILE_PATH = 'https://raw.githubusercontent.com/cfpb/consumer-credit-trends/master/data/';
+
 function init() {
-
-  console.log( ' map it upppp')
-
-  var tileMaps = {
-    'Auto Loans': {
-      'selector': '#figure-1c__map__auto',
-      'dataUrl': 'https://raw.githubusercontent.com/cfpb/consumer-credit-trends/master/data/map_data_AUT.csv'
-    },
-    'Credit Cards': {
-      'selector': '#figure-1c__map__credit-cards',
-      'dataUrl': 'https://raw.githubusercontent.com/cfpb/consumer-credit-trends/master/data/map_data_CRC.csv'
-    },
-    'Mortgages': {
-      'selector': '#figure-1c__map__mortgage',
-      // 'selector': '#mortgage_geo-changes',
-      'dataUrl': 'https://raw.githubusercontent.com/cfpb/consumer-credit-trends/master/data/map_data_MTG.csv'
-    },
-    'Student Loans': {
-      'selector': '#figure-1c__map__student',
-      // 'selector': '#student-loan_geo-changes',
-      'dataUrl': 'https://raw.githubusercontent.com/cfpb/consumer-credit-trends/master/data/map_data_STU.csv'
-    }
-  };
-
 
   var defaultOpts = {
     baseWidth: 770,
@@ -50,10 +28,10 @@ function init() {
 
   // Make the Tile Maps
 
-  function makeDataIntoTileMaps( chartInfo ) {
+  function makeDataIntoTileMaps( file, elementID, chartGroup ) {
 
 
-    d3.csv( chartInfo.dataUrl, function( error, rawData ) {
+    d3.csv( DATA_FILE_PATH + file, function( error, rawData ) {
       var data = [];
       for (var x = 0; x < rawData.length; x++ ) {
         var obj = {};
@@ -74,7 +52,7 @@ function init() {
 
       var autoLoanMapProps = {
         data: data,
-        selector: chartInfo.selector,
+        selector: '#' + elementID,
         valueGrid: valudGrid,
         legendLabels: legendLabels,
       }
@@ -95,10 +73,17 @@ function init() {
     } );
   }
 
-  for( var key in tileMaps ) {
-    var chartInfo = tileMaps[key];
-    makeDataIntoTileMaps( chartInfo );
-  }
+  for ( var i = 0; i < charts.length; i++ ) {
+    var chart = charts[i];
+    var source = chart.source;
+    var chartID = chart.elementID;
+    var chartType = chart.chartType;
+    var chartGroup = chart.group ? chart.group : null;
+
+    if ( chartType === 'map' && document.getElementById( chartID ) ) {
+      makeDataIntoTileMaps( source, chartID, chartGroup );
+    }
+  };
 
 
 }

--- a/src/static/js/tile-map.js
+++ b/src/static/js/tile-map.js
@@ -6,65 +6,100 @@ var getFipsAbbr = require( './utils/state-fips.js' ).getAbbr;
 var dateTranslate = require( './utils/date-translate.js' );
 var strToNum = require( './utils/string-to-number.js' );
 var formatTime = d3.utcFormat( '%b %Y' );
-
+var charts = require( './templates/charts.js' ); 
 
 function init() {
 
-  console.log( ' map it up')
+  console.log( ' map it upppp')
 
-var autoLoanMapData = [];
-var DATA_URLS = {
-  MAP: 'https://raw.githubusercontent.com/cfpb/consumer-credit-trends/master/data/map_data_AUT.csv'
-}
+  var tileMaps = {
+    'Auto Loans': {
+      'selector': '#figure-1c__map__auto',
+      'dataUrl': 'https://raw.githubusercontent.com/cfpb/consumer-credit-trends/master/data/map_data_AUT.csv'
+    },
+    'Credit Cards': {
+      'selector': '#figure-1c__map__credit-cards',
+      'dataUrl': 'https://raw.githubusercontent.com/cfpb/consumer-credit-trends/master/data/map_data_CRC.csv'
+    },
+    'Mortgages': {
+      'selector': '#figure-1c__map__mortgage',
+      // 'selector': '#mortgage_geo-changes',
+      'dataUrl': 'https://raw.githubusercontent.com/cfpb/consumer-credit-trends/master/data/map_data_MTG.csv'
+    },
+    'Student Loans': {
+      'selector': '#figure-1c__map__student',
+      // 'selector': '#student-loan_geo-changes',
+      'dataUrl': 'https://raw.githubusercontent.com/cfpb/consumer-credit-trends/master/data/map_data_STU.csv'
+    }
+  };
 
-var defaultOpts = {
-  baseWidth: 770,
-  baseHeight: 500,
-  paddingDecimal: .1,
-  margin: {
-    top: 100, right: 20, bottom: 70, left: 70
-  }
-}
 
-d3.csv( DATA_URLS.MAP, function( error, rawData ) {
-  for (var x = 0; x < rawData.length; x++ ) {
-    var obj = {};
-    obj.state = getFipsAbbr( rawData[x].state );
-    obj.value = rawData[x].value;
-    autoLoanMapData.push( obj );
-  }
-
-  var autoLoanValueGrid = [
-    { maxValue: -0.15, fillColor: '#64a5d9' },
-    { maxValue: -0.05, fillColor: '#c4ddf3' },
-    { maxValue: 0.05, fillColor: '#f7f8f9' },
-    { maxValue: 0.15, fillColor: '#bbdca2' },
-    { maxValue: 'any', fillColor: '#6abf69' }
-  ];
-
-  var autoMapLegendLabels = [ '-25%', '-15%', '-5%', '5%', '15%', '25%' ];
-
-  var autoLoanMapProps = {
-    data: autoLoanMapData,
-    selector: '#auto-loan_geo-changes',
-    valueGrid: autoLoanValueGrid,
-    legendLabels: autoMapLegendLabels,
-  }
-
-  var AutoLoanMap = new chartBuilder.tileMap( autoLoanMapProps );
-
-  var AutoLoanMapOptions = {
-    baseWidth: 650,
-    baseHeight: 650,
+  var defaultOpts = {
+    baseWidth: 770,
+    baseHeight: 500,
     paddingDecimal: .1,
     margin: {
-      top: 20, right: 20, bottom: 20, left: 20
+      top: 100, right: 20, bottom: 70, left: 75
     }
   }
 
-  var AutoLoanMapChart = AutoLoanMap.drawGraph( AutoLoanMapOptions );
 
-} );
+  // *********** //
+  // THE CHARTS
+  // *********** //
+
+  // Make the Tile Maps
+
+  function makeDataIntoTileMaps( chartInfo ) {
+
+
+    d3.csv( chartInfo.dataUrl, function( error, rawData ) {
+      var data = [];
+      for (var x = 0; x < rawData.length; x++ ) {
+        var obj = {};
+        obj.state = getFipsAbbr( rawData[x].state );
+        obj.value = rawData[x].value;
+        data.push( obj );
+      }
+
+      var valudGrid = [
+        { maxValue: -0.15, fillColor: '#64a5d9' },
+        { maxValue: -0.05, fillColor: '#c4ddf3' },
+        { maxValue: 0.05, fillColor: '#f7f8f9' },
+        { maxValue: 0.15, fillColor: '#bbdca2' },
+        { maxValue: 'any', fillColor: '#6abf69' }
+      ];
+
+      var legendLabels = [ '-25%', '-15%', '-5%', '5%', '15%', '25%' ];
+
+      var autoLoanMapProps = {
+        data: data,
+        selector: chartInfo.selector,
+        valueGrid: valudGrid,
+        legendLabels: legendLabels,
+      }
+
+      var tileMapObj = new chartBuilder.tileMap( autoLoanMapProps );
+
+      var tileOpts = {
+        baseWidth: 650,
+        baseHeight: 650,
+        paddingDecimal: .1,
+        margin: {
+          top: 20, right: 20, bottom: 20, left: 20
+        }
+      }
+
+      var tileMapChart = tileMapObj.drawGraph( tileOpts );
+
+    } );
+  }
+
+  for( var key in tileMaps ) {
+    var chartInfo = tileMaps[key];
+    makeDataIntoTileMaps( chartInfo );
+  }
+
 
 }
 


### PR DESCRIPTION
## Additions

- Added tile maps code from `voltron` branch and updated chart builder to latest version
- hooked up tile maps params from the charts.js config

## Changes

- had to specify the # for id for the tile map selector param - would be nice to make this accept other selects or just a string upstream in chart-builder mayhaps? def not needed for MVP

## Testing

- check out this branch
- gulp build and gulp watch it

## Review

- @mistergone 
- @marteki  

[Preview this PR without the whitespace changes](?w=0)

## Screenshots


![screen shot 2016-12-12 at 1 03 00 pm](https://cloud.githubusercontent.com/assets/702526/21110539/93cc5d9c-c06b-11e6-82f8-4a8c0d34276b.png)
![screen shot 2016-12-12 at 1 02 57 pm](https://cloud.githubusercontent.com/assets/702526/21110541/93d3d3ec-c06b-11e6-838d-3d7d39d29b56.png)
![screen shot 2016-12-12 at 1 02 54 pm](https://cloud.githubusercontent.com/assets/702526/21110540/93d291ee-c06b-11e6-8a21-82af9b99a03e.png)
![screen shot 2016-12-12 at 1 02 50 pm](https://cloud.githubusercontent.com/assets/702526/21110542/93d6aa2c-c06b-11e6-9cba-aebfbbc6c917.png)
