### PR TITLE
Issue Fixes

### DIFF
--- a/src/static/js/bar.js
+++ b/src/static/js/bar.js
@@ -26,7 +26,6 @@ function init() {
 
 }
 
-
 // HELPER FUNCTIONS
 
 function makeDataIntoBarCharts( chartInfo ) {
@@ -34,11 +33,11 @@ function makeDataIntoBarCharts( chartInfo ) {
     var data = rawData;
 
     var defaultOpts = {
-      baseWidth: 770,
+      baseWidth: 670,
       baseHeight: 500,
       paddingDecimal: .1,
       margin: {
-        top: 85, right: 20, bottom: 30, left: 75
+        top: 85, right: 20, bottom: 50, left: 75
       }
     }
 
@@ -87,7 +86,7 @@ function reformatBarData( rawData ) {
     }; 
 
     // add data if it's 2009 or after
-    if ( parseTime( obj.label ) >= parseTime( '2009-0-01') ) {
+    if ( parseTime( obj.label ) >= parseTime( '2009-01-01') ) {
       data.push( obj );
     }
 

--- a/src/static/js/line.js
+++ b/src/static/js/line.js
@@ -22,8 +22,6 @@ function init() {
       makeDataIntoLineCharts( chartInfo );
     }
   };
-
-
 }
 
 
@@ -35,11 +33,11 @@ function makeDataIntoLineCharts( chartInfo ) {
   d3.csv( chartInfo.dataUrl, function( error, rawData ) {
 
     var defaultOpts = {
-      baseWidth: 770,
-      baseHeight: 550,
+      baseWidth: 670,
+      baseHeight: 500,
       paddingDecimal: .1,
       margin: {
-        top: 85, right: 20, bottom: 30, left: 75
+        top: 85, right: 20, bottom: 50, left: 75
       }
     }
 
@@ -141,7 +139,7 @@ function reformatLineData( rawData, maxMonth, multiGroup ) {
     } 
 
     // add data if it's 2009 or after
-    if ( obj.x >= parseTime( '2009-0-01') ) {
+    if ( obj.x >= parseTime( '2009-01-01') ) {
       data.push( obj );
     }
   };

--- a/src/static/js/templates/svg.hbs
+++ b/src/static/js/templates/svg.hbs
@@ -19,7 +19,7 @@
     </div><!-- .svg_wrapper -->
 
     <p class="block__sub block__border-top block short-desc chart_footnote">
-        <strong>Source:</strong> <a href="https://raw.githubusercontent.com/cfpb/consumer-credit-trends/master/data/{{ source }}">https://raw.githubusercontent.com/cfpb/consumer-credit-trends/master/data/{{ source }}</a><br>
+        <strong>Source:</strong> <a href="https://raw.githubusercontent.com/cfpb/consumer-credit-trends/master/data/{{ source }}">Download CSV file</a><br>
         <strong>Date published:</strong> December 2016<br>
         <strong>Note:</strong> Data from the last 6 months is not final.
     </p>


### PR DESCRIPTION
- fixes #25 graphs starting before 2009 
- fixes #28 graphs too wide for container
- X-Axis labels fixed for new smaller width

## Changes
- Changed `width` in options for line and bar graphs
- Fixed typo in date limiter for line and bar graphs
- Changed y-axis labels to "two lines" for bar and line graphs

## Review
- @cfarm @marteki 

[Preview this PR without the whitespace changes](?w=0)