### PR TITLE
fix label colors so all are gray-80

### DIFF
--- a/src/static/css/charts.less
+++ b/src/static/css/charts.less
@@ -11,20 +11,6 @@
 
 .chart_wrapper {
 
-    .chart {
-          text.gray-text {
-            fill: @gray-80;
-          }
-
-          text.y-axis-label {
-            fill: @gray-80;
-          }
-    }
-
-    .chart__line {
-
-    }
-
     .line {
       fill: none;
       stroke: @gray-80;
@@ -98,6 +84,14 @@
 
     text.state-abbreviation {
         .webfont-demi();
+    }
+
+    text.gray-text {
+        fill: @gray-80;
+    }
+    
+    text.y-axis-label {
+        fill: @gray-80;
     }
 
     .axis path.domain {


### PR DESCRIPTION
## Changes

- Fix CSS to match updated markup so text is gray on graph labels

## Review

- @marteki 
- @ajbush 

[Preview this PR without the whitespace changes](?w=0)

## Screenshots
![screen shot 2016-12-13 at 1 38 21 pm](https://cloud.githubusercontent.com/assets/702526/21153697/9be50686-c139-11e6-9053-86b9831a393b.png)


