### PR TITLE
fix line+bar chart widths for wagtail

### DIFF
--- a/src/static/js/bar.js
+++ b/src/static/js/bar.js
@@ -33,7 +33,7 @@ function makeDataIntoBarCharts( chartInfo ) {
     var data = rawData;
 
     var defaultOpts = {
-      baseWidth: 670,
+      baseWidth: 650,
       baseHeight: 500,
       paddingDecimal: .1,
       margin: {

--- a/src/static/js/line.js
+++ b/src/static/js/line.js
@@ -33,7 +33,7 @@ function makeDataIntoLineCharts( chartInfo ) {
   d3.csv( chartInfo.dataUrl, function( error, rawData ) {
 
     var defaultOpts = {
-      baseWidth: 670,
+      baseWidth: 650,
       baseHeight: 500,
       paddingDecimal: .1,
       margin: {


### PR DESCRIPTION
Fixes widths for line + bar charts so they fit into Wagtail layout.

## Changes

- changed with to 650 to match the map 

## Testing

- check it out on build server at `/data-research/consumer-credit-markets-AJ/auto-loans-market-monitoring-report-v3/origination-activity-svgs/`

## Review

- @marteki 
- @ajbush 

[Preview this PR without the whitespace changes](?w=0)

## Screenshots
![screen shot 2016-12-13 at 2 32 42 pm](https://cloud.githubusercontent.com/assets/702526/21155673/08943b24-c141-11e6-8a25-dc70e1a566f2.png)
![screen shot 2016-12-13 at 2 32 36 pm](https://cloud.githubusercontent.com/assets/702526/21155674/0894b5f4-c141-11e6-98aa-292d4600fdc9.png)
![screen shot 2016-12-13 at 2 32 28 pm](https://cloud.githubusercontent.com/assets/702526/21155675/089553ce-c141-11e6-8a59-2facb1e640c7.png)


