### PR TITLE
Fix tags and whitespace in static HTML output

### DIFF
--- a/gulp/tasks/release.js
+++ b/gulp/tasks/release.js
@@ -14,6 +14,7 @@ var browserSync = require( 'browser-sync' );
 var release = config.copy.release;
 var deleteLines = require('gulp-delete-lines');
 var htmlreplace = require('gulp-html-replace');
+var htmlmin = require('gulp-htmlmin');
 
 // Add charts.min.css to static chart files as <style> tag
 gulp.task('release:addStyleElement', [ 'release:copyFiles' ], function() {
@@ -48,8 +49,11 @@ gulp.task( 'release',
   gulp.src( release.destFiles )
     .pipe( deleteLines( {
       'filters': [
-        /<script\s+class=/i,
+        /<script\s+class=/i
       ]
+    } ) )
+    .pipe(htmlmin( {
+      collapseWhitespace: true
     } ) )
     .pipe( gulp.dest( release.dest + '/charts/') );
 

--- a/gulp/tasks/release.js
+++ b/gulp/tasks/release.js
@@ -14,15 +14,6 @@ var browserSync = require( 'browser-sync' );
 var release = config.copy.release;
 var deleteLines = require('gulp-delete-lines');
 var htmlreplace = require('gulp-html-replace');
-var htmlmin = require('gulp-htmlmin');
-
-// gulp.task('release:minify', function() {
-//   return gulp.src( '/*.html' )
-//     .pipe(htmlmin( {
-//       maxLineLength: 200
-//     } ) )
-//     .pipe(gulp.dest( 'dist' ) );
-// });
 
 // Add charts.min.css to static chart files as <style> tag
 gulp.task('release:addStyleElement', [ 'release:copyFiles' ], function() {
@@ -53,31 +44,13 @@ gulp.task( 'release',
     'handlebars:dom',
   ], function() {
 
-    // remove script tag from static file output
-  // gulp.src( release.destFiles )
-  //   .pipe(htmlreplace({
-  //     'js': {
-  //       src: '',
-  //       tpl: ''
-  //     }
-  //   }))
-  //   .pipe( gulp.dest( release.dest + '/charts/') );
-
   // remove scripts
   gulp.src( release.destFiles )
     .pipe( deleteLines( {
       'filters': [
         /<script\s+class=/i,
-        // /huh/
-        // /<script class="jsdom" src="http:\/\/localhost:3000\/static\/js\/main\.min\.js"><\/script>/
-        // /<script src="\.\.\/\.\.\/\.\.\/static\/js\/main\.min\.js"><\/script>/
       ]
     } ) )
-    // return gulp.src( '/*.html' )
-    // .pipe(htmlmin( {
-    //   maxLineLength: 200
-    // } ) )
-    // .pipe(gulp.dest( 'dist' ) );
     .pipe( gulp.dest( release.dest + '/charts/') );
 
 } );

--- a/gulp/tasks/release.js
+++ b/gulp/tasks/release.js
@@ -14,6 +14,15 @@ var browserSync = require( 'browser-sync' );
 var release = config.copy.release;
 var deleteLines = require('gulp-delete-lines');
 var htmlreplace = require('gulp-html-replace');
+var htmlmin = require('gulp-htmlmin');
+
+// gulp.task('release:minify', function() {
+//   return gulp.src( '/*.html' )
+//     .pipe(htmlmin( {
+//       maxLineLength: 200
+//     } ) )
+//     .pipe(gulp.dest( 'dist' ) );
+// });
 
 // Add charts.min.css to static chart files as <style> tag
 gulp.task('release:addStyleElement', [ 'release:copyFiles' ], function() {
@@ -24,6 +33,7 @@ gulp.task('release:addStyleElement', [ 'release:copyFiles' ], function() {
         tpl: '<style>%s</style>'
       }
     }))
+
     .pipe(gulp.dest( './dist' ));
 });
 
@@ -43,13 +53,31 @@ gulp.task( 'release',
     'handlebars:dom',
   ], function() {
 
+    // remove script tag from static file output
+  // gulp.src( release.destFiles )
+  //   .pipe(htmlreplace({
+  //     'js': {
+  //       src: '',
+  //       tpl: ''
+  //     }
+  //   }))
+  //   .pipe( gulp.dest( release.dest + '/charts/') );
+
   // remove scripts
   gulp.src( release.destFiles )
     .pipe( deleteLines( {
       'filters': [
-        /<script\s/i
+        /<script\s+class=/i,
+        // /huh/
+        // /<script class="jsdom" src="http:\/\/localhost:3000\/static\/js\/main\.min\.js"><\/script>/
+        // /<script src="\.\.\/\.\.\/\.\.\/static\/js\/main\.min\.js"><\/script>/
       ]
     } ) )
+    // return gulp.src( '/*.html' )
+    // .pipe(htmlmin( {
+    //   maxLineLength: 200
+    // } ) )
+    // .pipe(gulp.dest( 'dist' ) );
     .pipe( gulp.dest( release.dest + '/charts/') );
 
 } );

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -555,6 +555,11 @@
       "from": "callsites@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz"
     },
+    "camel-case": {
+      "version": "3.0.0",
+      "from": "camel-case@>=3.0.0 <3.1.0",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz"
+    },
     "camelcase": {
       "version": "2.1.1",
       "from": "camelcase@>=2.0.0 <3.0.0",
@@ -668,7 +673,8 @@
     },
     "cfpb-chart-builder": {
       "version": "0.0.8",
-      "from": "cfpb-chart-builder@0.0.8"
+      "from": "cfpb-chart-builder@0.0.8",
+      "resolved": "https://registry.npmjs.org/cfpb-chart-builder/-/cfpb-chart-builder-0.0.8.tgz"
     },
     "chalk": {
       "version": "1.1.3",
@@ -3291,6 +3297,11 @@
       "from": "hawk@>=3.1.3 <3.2.0",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
     },
+    "he": {
+      "version": "1.1.0",
+      "from": "he@>=1.1.0 <1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.0.tgz"
+    },
     "hoek": {
       "version": "2.16.3",
       "from": "hoek@>=2.0.0 <3.0.0",
@@ -3320,6 +3331,11 @@
       "version": "1.0.1",
       "from": "html-encoding-sniffer@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.1.tgz"
+    },
+    "html-minifier": {
+      "version": "3.2.3",
+      "from": "html-minifier@>=3.0.3 <4.0.0",
+      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.2.3.tgz"
     },
     "html5shiv": {
       "version": "3.7.3",
@@ -4247,6 +4263,11 @@
       "from": "loud-rejection@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz"
     },
+    "lower-case": {
+      "version": "1.1.3",
+      "from": "lower-case@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.3.tgz"
+    },
     "lowercase-keys": {
       "version": "1.0.0",
       "from": "lowercase-keys@>=1.0.0 <2.0.0",
@@ -4462,6 +4483,11 @@
       "from": "natives@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz"
     },
+    "ncname": {
+      "version": "1.0.0",
+      "from": "ncname@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/ncname/-/ncname-1.0.0.tgz"
+    },
     "nconf": {
       "version": "0.7.2",
       "from": "nconf@>=0.7.2 <0.8.0",
@@ -4483,6 +4509,11 @@
       "version": "1.0.2",
       "from": "nested-error-stacks@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-1.0.2.tgz"
+    },
+    "no-case": {
+      "version": "2.3.0",
+      "from": "no-case@>=2.2.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.0.tgz"
     },
     "node-emoji": {
       "version": "1.4.3",
@@ -4765,6 +4796,11 @@
       "version": "0.2.9",
       "from": "pako@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz"
+    },
+    "param-case": {
+      "version": "2.1.0",
+      "from": "param-case@>=2.1.0 <2.2.0",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.0.tgz"
     },
     "parse-filepath": {
       "version": "1.0.1",
@@ -5147,6 +5183,11 @@
       "version": "3.1.0",
       "from": "registry-url@>=3.0.3 <4.0.0",
       "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz"
+    },
+    "relateurl": {
+      "version": "0.2.7",
+      "from": "relateurl@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz"
     },
     "remote-content": {
       "version": "1.0.1",
@@ -6241,6 +6282,11 @@
         }
       }
     },
+    "upper-case": {
+      "version": "1.1.3",
+      "from": "upper-case@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz"
+    },
     "urix": {
       "version": "0.1.0",
       "from": "urix@>=0.1.0 <0.2.0",
@@ -6620,6 +6666,11 @@
       "version": "2.0.0",
       "from": "xdg-basedir@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz"
+    },
+    "xml-char-classes": {
+      "version": "1.0.0",
+      "from": "xml-char-classes@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/xml-char-classes/-/xml-char-classes-1.0.0.tgz"
     },
     "xml-name-validator": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "gulp-eslint": "2.0.0",
     "gulp-header": "1.8.8",
     "gulp-html-replace": "1.6.2",
+    "gulp-htmlmin": "3.0.0",
     "gulp-imagemin": "3.1.1",
     "gulp-inline-css": "3.1.0",
     "gulp-less": "3.3.0",

--- a/src/static/js/templates/svg.hbs
+++ b/src/static/js/templates/svg.hbs
@@ -21,7 +21,7 @@
     </div><!-- .svg_wrapper -->
 
     <p class="block__sub block__border-top block short-desc chart_footnote">
-        <strong>Source:</strong> <a href="https://raw.githubusercontent.com/cfpb/consumer-credit-trends/master/data/{{ source }}">https://raw.githubusercontent.com/cfpb/consumer-credit-trends/master/data/{{ source }}</a><br>
+        <strong>Source:</strong> <a href="https://raw.githubusercontent.com/cfpb/consumer-credit-trends/master/data/{{ source }}">Download CSV file</a><br>
         <strong>Date published:</strong> December 2016<br>
         <strong>Note:</strong> Data from the last 6 months is not final.
     </p>

--- a/src/static/js/templates/svg.hbs
+++ b/src/static/js/templates/svg.hbs
@@ -1,3 +1,5 @@
+
+
 <div class="chart_wrapper">
     <h3>{{ title }}</h3>
 
@@ -26,6 +28,7 @@
 
 
     {{#unless indexPage}}
-    <script src="../../../static/js/main.min.js"></script>
+    <script class="mainjs" src="../../../static/js/main.min.js"></script>
     {{/unless}}
 </div><!-- .chart_wrapper -->
+

--- a/src/static/js/templates/svg.hbs
+++ b/src/static/js/templates/svg.hbs
@@ -1,6 +1,12 @@
 
 
 <div class="chart_wrapper">
+    <!-- build:css -->
+    {{#unless indexPage}}
+    <link rel="stylesheet" href="../../../static/css/charts.min.css">
+    {{/unless}}
+    <!-- endbuild -->
+
     <h3>{{ title }}</h3>
 
     <div class="svg_wrapper"
@@ -11,14 +17,8 @@
         data-market="{{ market }}"
         data-report-type="{{ reportType }}"
     >
+    </div>
 
-        <!-- build:css -->
-        {{#unless indexPage}}
-        <link rel="stylesheet" href="../../../static/css/charts.min.css">
-        {{/unless}}
-        <!-- endbuild -->
-
-    </div><!-- .svg_wrapper -->
 
     <p class="block__sub block__border-top block short-desc chart_footnote">
         <strong>Source:</strong> <a href="https://raw.githubusercontent.com/cfpb/consumer-credit-trends/master/data/{{ source }}">Download CSV file</a><br>

--- a/src/static/js/utils/dom.js
+++ b/src/static/js/utils/dom.js
@@ -24,7 +24,7 @@ for ( var i = 0; i < charts.length; i++ ) {
         process.stdout.write( 'writing to: ' + filePath + '\n');
       }
 
-      window.setTimeout( getSVG, 10000 );
+      window.setTimeout( getSVG, 17000 );
 
     }
   } );


### PR DESCRIPTION
This cleans up the static output by doing the following:

- fixes missing closing div tags by updating the way we were removing script tags from the compiled files to be more specific about the code it touches. regexalicious
- adds html minifier to remove whitespace from output and compile html to a single line for easier copy/paste and fixed whitespace in the final Wagtail page

## Additions

- gulp plugin for minifying html

## Changes

- fix regex for removing script tags 
- re organize markup in svg file to make style tag come first
- increase timer for rendering svgs to compile step. was getting empty output files without this update.
- fix lost change for source to say 'download csv file'

## Testing

- check out branch
- run ./setup.sh, gulp watch, gulp release to get  updated compiled html.

## Review

- @hillaryj 
- @marteki 

[Preview this PR without the whitespace changes](?w=0)

## Screenshots

