### PR TITLE
Fix projected line

### DIFF
--- a/gulp/tasks/handlebars.js
+++ b/gulp/tasks/handlebars.js
@@ -64,7 +64,7 @@ gulp.task( 'handlebars:index',
     charts: charts
   }
 
-  console.log(chartData.charts)
+  // console.log(chartData.charts)
 
   gulp.src( indexSrc )
     .pipe( handlebars( chartData, options ) )

--- a/src/static/css/charts.less
+++ b/src/static/css/charts.less
@@ -45,15 +45,8 @@
     }
 
     .axis__projected {
-        .tick {
-            line {
-                stroke-width: 2px;
-                stroke: @gray-80;
-            }
-            text {
-                fill: @gray-80;
-            }
-        }
+        stroke-width: 2px;
+        stroke: @gray-80;
     }
 
     .tick {

--- a/src/static/js/bar.js
+++ b/src/static/js/bar.js
@@ -116,11 +116,11 @@ function addProjectedToBar( svg, options ) {
     .attr( 'class', 'bar__projected' );
 
   var line = svg.chart.append( 'line' )
-        .style( 'stroke', ' #919395' )
         .attr( 'x1', x )
         .attr( 'x2', x )
         .attr( 'y1', -30 )
-        .attr( 'y2', height );
+        .attr( 'y2', height )
+        .classed( 'axis__projected', true);
 
   svg.chart.append( 'text' )
       .attr('x', x )

--- a/src/static/js/line.js
+++ b/src/static/js/line.js
@@ -159,11 +159,11 @@ function addProjectedToLine( chartObject, date, height ) {
       y = chartObject.y;
 
   var line = chartObject.chart.append( 'line' )
-      .style( 'stroke', ' #919395' )
       .attr( 'x1', x( date ) )
       .attr( 'x2', x( date ) )
       .attr( 'y1', -30 )
-      .attr( 'y2', height );
+      .attr( 'y2', height )
+      .classed( 'axis__projected', true);
 
   chartObject.chart.append( 'text' )
       .attr('x', x( date ) )


### PR DESCRIPTION
Wagtail didn't like how the projected line was being styled inline before, so this adds a class and CSS for it that works.

See build/`data-research/consumer-credit-markets-AJ/auto-loans-market-monitoring-report-v3/borrower-age-svg/` first graph on that page for an example of the static output from this branch

