### PR TITLE
add block class to add whitespace above charts

### DIFF
--- a/src/static/js/templates/svg.hbs
+++ b/src/static/js/templates/svg.hbs
@@ -1,6 +1,6 @@
 
 
-<div class="chart_wrapper">
+<div class="chart_wrapper block">
     <!-- build:css -->
     {{#unless indexPage}}
     <link rel="stylesheet" href="../../../static/css/charts.min.css">


### PR DESCRIPTION
Adds `block` class to the chart wrapper div so that there is additional whitespace above graphs in Wagtail.

A short term MVP hack that doesn't require re compiling and copy and pasting all graphs is to add the following style tag to any Wagtail page content block:

```
<style>.chart_wrapper { margin-top: 3.75em;margin-bottom: 3.75em; }</style>
```

This PR's update can be deployed in subsequent releases, or if there is another drastic need to update all the graphs manually.

Here's how it looks:


#### Before
![screen shot 2016-12-13 at 11 29 38 pm](https://cloud.githubusercontent.com/assets/702526/21169636/0a6b3772-c18c-11e6-9955-281144e3c4ea.png)


#### After
![screen shot 2016-12-13 at 11 20 31 pm](https://cloud.githubusercontent.com/assets/702526/21169602/a0ae5468-c18b-11e6-9733-87a373140db3.png)

**Design note:** Compared to the .ai template, there is more space than the design says there should be above graphs that come after a paragraph (the design says 45px, the above screenshot shows 60px). This is because we can't really tell what graphs come after paragraphs due to the use of Wagtail and the HTML containers it adds around every content block.
