### PR TITLE
cfpb-chart-builder updated to 0.0.9

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -672,9 +672,8 @@
       "resolved": "https://registry.npmjs.org/cf-typography/-/cf-typography-3.1.0.tgz"
     },
     "cfpb-chart-builder": {
-      "version": "0.0.8",
-      "from": "git://github.com/cfpb/cfpb-chart-builder.git#22eff8c70f449324eb7152cb409cc377568dcc23",
-      "resolved": "git://github.com/cfpb/cfpb-chart-builder.git#22eff8c70f449324eb7152cb409cc377568dcc23"
+      "version": "0.0.9",
+      "from": "cfpb-chart-builder@0.0.9"
     },
     "chalk": {
       "version": "1.1.3",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -673,8 +673,8 @@
     },
     "cfpb-chart-builder": {
       "version": "0.0.8",
-      "from": "cfpb-chart-builder@0.0.8",
-      "resolved": "https://registry.npmjs.org/cfpb-chart-builder/-/cfpb-chart-builder-0.0.8.tgz"
+      "from": "git://github.com/cfpb/cfpb-chart-builder.git#22eff8c70f449324eb7152cb409cc377568dcc23",
+      "resolved": "git://github.com/cfpb/cfpb-chart-builder.git#22eff8c70f449324eb7152cb409cc377568dcc23"
     },
     "chalk": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "cf-pagination": "3.1.1",
     "cf-tables": "1.1.0",
     "cf-typography": "3.1.0",
-    "cfpb-chart-builder": "git://github.com/cfpb/cfpb-chart-builder.git#tick-thinker",
+    "cfpb-chart-builder": "0.0.9",
     "github-api": "2.3.0",
     "gulp-connect": "5.0.0",
     "html5shiv": "3.7.3",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "cf-pagination": "3.1.1",
     "cf-tables": "1.1.0",
     "cf-typography": "3.1.0",
-    "cfpb-chart-builder": "0.0.8",
+    "cfpb-chart-builder": "git://github.com/cfpb/cfpb-chart-builder.git#tick-thinker",
     "github-api": "2.3.0",
     "gulp-connect": "5.0.0",
     "html5shiv": "3.7.3",

--- a/src/static/js/bar.js
+++ b/src/static/js/bar.js
@@ -23,7 +23,6 @@ function init() {
     }
   };
 
-
 }
 
 


### PR DESCRIPTION
Updates `cfpb-chart-builder` to `0.0.9`, fixing y-axis tick mark bug. Also ran `npm shrinkwrap`.

## Changes
- Updates `cfpb-chart-builder` to version `0.0.9`

## Review
- @cfarm @hillaryj @marteki  

[Preview this PR without the whitespace changes](?w=0)
